### PR TITLE
melhoria na seção da equipe para responsivo

### DIFF
--- a/css/Arquivo.css
+++ b/css/Arquivo.css
@@ -86,6 +86,7 @@ a:link {
 .center {
     display: flex;
     justify-content: center;
+    flex-wrap: wrap;
 }
 
 h1 {


### PR DESCRIPTION
ao acessar a versão atual em dispositivos de tela menores, é possível notar que vários membros da equipe não aparecem.
isso é causado pelo [flexbox](https://developer.mozilla.org/pt-BR/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox), utilizado na div para centralizar os itens, que por sua vez não quebra a linha por padrão,
pra correção foi necessário apenas passar o parâmetro que permite a quebra de linha ([flex-wrap](https://developer.mozilla.org/pt-BR/docs/Web/CSS/flex-wrap)) quando exceder o espaço.

espero ter ajudado,
abraço!